### PR TITLE
Unit testing

### DIFF
--- a/js/__tests__/gamestate-test.js
+++ b/js/__tests__/gamestate-test.js
@@ -1,0 +1,8 @@
+jest.dontMock("../gamestate")
+
+describe("GameState", function() {
+  it("can be created", function() {
+    let GameState = require("../gamestate")
+    let state = new GameState("bob")
+  })
+})

--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
     "webpack": "~1.9.10",
     "babel-core": "~5.5.6",
     "babel-loader": "~5.1.4",
-    "jest-cli": "~0.4.13"
+    "jest-cli": "~0.4.13",
+    "babel-jest": "~5.3.0"
   },
   "dependencies": {
     "babel": "^5.5.6",
@@ -39,5 +40,10 @@
     "seedrandom": "^2.4.0",
     "style-loader": "^0.12.3",
     "ws": "~0.7.2"
+  },
+  "jest": {
+    "scriptPreprocessor": "<rootDir>/node_modules/babel-jest",
+    "testFileExtensions": ["es6", "js"],
+    "moduleFileExtensions": ["js", "json", "es6"]
   }
 }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "index.js",
   "scripts": {
     "start": "webpack-dev-server --hot --progress --colors",
-    "build": "webpack --hot --progress --colors"
+    "build": "webpack --hot --progress --colors",
+    "test": "jest"
   },
   "repository": {
     "type": "git",
@@ -27,7 +28,8 @@
     "node-libs-browser": "~0.5.2",
     "webpack": "~1.9.10",
     "babel-core": "~5.5.6",
-    "babel-loader": "~5.1.4"
+    "babel-loader": "~5.1.4",
+    "jest-cli": "~0.4.13"
   },
   "dependencies": {
     "babel": "^5.5.6",


### PR DESCRIPTION
This sets up Jest (with babel-jest for es6 support) as our unit testing framework. Stick tests in the **tests** directory, then run `npm test` to run the tests. So far just tests that a GameState can be constructed ok.
