### PR TITLE
fix two bugs in GameState serialization

### DIFF
--- a/js/__tests__/gamestate-test.js
+++ b/js/__tests__/gamestate-test.js
@@ -23,4 +23,25 @@ describe("GameState", function() {
     expect(state2.turn).toEqual(state.turn)
     expect(state2.winner).toEqual(state.winner)
   })
+
+  it("retains card function across reserialization", function() {
+    let state = new GameState({name: "bob"})
+    state.startGame(["bob", "eve"], 123)
+    state.makeMove({op: "endTurn"})
+    state.makeMove({op: "beginTurn"})
+    state.makeMove({op: "endTurn"})
+    state.makeMove({op: "beginTurn"})
+    let data = JSON.stringify(state)
+    let state2 = new GameState(JSON.parse(data))
+
+    expect(state2.name).toEqual(state.name)
+    expect(state2._started).toEqual(state._started)
+    expect(state2.turn).toEqual(state.turn)
+    expect(state2.winner).toEqual(state.winner)
+
+    expect(
+      state2.current().getHand(0).name).toEqual(
+      state.current().getHand(0).name)
+
+  })
 })

--- a/js/gamestate.js
+++ b/js/gamestate.js
@@ -93,11 +93,11 @@ class GameState {
     // We just start off with it not being our turn so that the UI
     // will be disabled - when we actually start the game it may or
     // may not be our turn.
-    this.turn = data.turn || 1
+    this.turn = (data.turn == null) ? 1 : data.turn
 
-    this.players = data.players || [
-      new PlayerState({name: this.name}),
-      new PlayerState({name: "waiting for opponent..."})]
+    let playerInfo = data.players || [{name: this.name},
+                                      {name: "waiting for opponent..."}]
+    this.players = playerInfo.map(info => new PlayerState(info))
 
     // The name of the winner
     this.winner = data.winner || null


### PR DESCRIPTION
The getHand function was getting totally lost, because after deserialization it wasn't a PlayerState it was just a classless object.

Also turn was getting deserialized wrong, due to some 0 vs false vs undefined confusion.
