### PR TITLE
change the op model to servers provide ids and define ordering

### DIFF
--- a/js/gamestate.js
+++ b/js/gamestate.js
@@ -62,7 +62,7 @@ const CARDS = [
   {
     name: "Electromagnetic Pulse",
     description: "Destroy all cards in play.",
-    flavor: "Put all your eggs in one basket, and watch that basket.",
+    flavor: "Watch that basket.",
     emp: true,
     cost: 4
   },


### PR DESCRIPTION
The game works. There's a bit more latency but I don't find it too bad. It still needs more resiliency but now I want to make sure we have the network event model correct before hardening it too much with retries, etc. So you can now have players submitting events at the same time, and each game will just display in the order the server decides.
